### PR TITLE
Set pentad attributes to "constant" to avoid sf warning

### DIFF
--- a/R/abapToSpOcc_single.R
+++ b/R/abapToSpOcc_single.R
@@ -46,12 +46,12 @@ abapToSpOcc_single <- function(abap_data, pentads = NULL){
     ## Extract spatial data
     if(!is.null(pentads)){
 
-        pentads <- pentads %>%
-            dplyr::filter(pentad %in% pentad_id)
+        sf::st_agr(pentads) = "constant"
 
-        pentad_xy <- sf::st_coordinates(
-            sf::st_centroid(pentads)
-        )
+        pentad_xy <- pentads %>%
+            dplyr::filter(pentad %in% pentad_id) %>%
+            sf::st_centroid() %>%
+            sf::st_coordinates()
     }
 
     ## Create empty arrays


### PR DESCRIPTION
The `attribute variables are assumed to be spatially constant throughout all geometries` warning was appearing after each `st_centroid()` call. Attributes of the pentad sf object are now set to "constant" to avoid this. See [here ](https://github.com/r-spatial/sf/issues/406) for more info.