### PR TITLE
Project pentad centroids using Albers Equal Area

### DIFF
--- a/R/abapToSpOcc_single.R
+++ b/R/abapToSpOcc_single.R
@@ -1,17 +1,21 @@
 #' ABAP to spOccupancy (single-species)
 #'
-#' @description This function transforms a raw ABAP data frame (returned by \code{\link{getAbapData}}) into an list which can be used to fit single-species occupancy models using \code{\link[spOccupancy]{spPGOcc}}(spatial) or \code{\link[spOccupancy]{PGOcc}}(non-spatial). The `spOccupancy` package fits single-species, multi-species, and integrated non-spatial and spatial occupancy models using Markov Chain Monte Carlo (MCMC).
+#' @description This function transforms a raw ABAP data frame (returned by \code{\link{getAbapData}}) into an list which can be used to fit single-species occupancy models using \code{\link[spOccupancy]{spPGOcc}} (spatial) or \code{\link[spOccupancy]{PGOcc}} (non-spatial). The `spOccupancy` package fits single-species, multi-species, and integrated non-spatial and spatial occupancy models using Markov Chain Monte Carlo (MCMC).
 #'
 #' @param abap_data single-season ABAP data downloaded using \code{\link{getAbapData}}.
-#' @param pentads an sf object returned by \code{\link{getRegionPentads}}. Defaults to `NULL`.
+#' @param pentads an `sf` object returned by \code{\link{getRegionPentads}}. Defaults to `NULL`.
+#' @param proj_coords logical value indicating whether pentad coordinates are projected (`TRUE`) or kept in decimal degree format (`FALSE`). Defaults to `TRUE`. See details below for coordinate reference system used during transformation.
 #'
 #' @return A list containing data necessary for model fitting in `spOccupancy`. List elements are `y` (detection/non-detection data), `det.covs` (survey-level covariates), and `coords` (x and y centroids of pentads if spatial data are supplied).
 #'
-#' @details The \code{\link[spOccupancy]{spPGOcc}} function takes `coords` as an argument with X and Y coordinates included for each site. Within the context of ABAP these `coords` are the centroid of each sampling pentad. In order to provide these spatial data to this function, simply use \code{\link{getRegionPentads}} and provide the same inputs for `.region_type` and `.region` that are specified in corresponding \code{\link{getAbapData}} call.\cr
+#' @details The \code{\link[spOccupancy]{spPGOcc}} function takes `coords` as an argument with X and Y coordinates included for each site. Within the context of ABAP, these `coords` are the centroid of each sampling pentad. In order to provide these spatial data to this function, simply use \code{\link{getRegionPentads}} and provide the same inputs for `.region_type` and `.region` that are specified in corresponding \code{\link{getAbapData}} call. If proj_coords is set to `TRUE` then the coordinates will be transformed using the African Albers Equal Area coordinate system (see \href{https://spatialreference.org/ref/esri/africa-albers-equal-area-conic/}{here} for details). This projection is best suited for land masses extending in an east-to-west orientation at mid-latitudes making it suitable for projecting pentads in Southern Africa. The functions in the `spOccupancy` package assume that coordinates are projected so for best results it is recommended to always project the data. \cr
 #'
 #' If `pentads` are specified then the output can be automatically used in \code{\link[spOccupancy]{spPGOcc}}. If no spatial data are provided the output can be used in \code{\link[spOccupancy]{PGOcc}}.\cr
 #'
 #' In addition to reformatting the detection/non-detection ABAP data for use in `spOccupancy` occupancy models, this function also extracts two survey-level covariates and adds them to the output list: ` hours` and `jday`. The `hours` variable is the total number of hours spent atlassing which is recorded on the pentad card and `jday` is the Julian day corresponding to the first day of atlassing for that card.
+#'
+#' @note The processing time of `abapToSpOcc_single` can be considerably long if the number of cards and pentads of the focal species is high, so patience may be required.
+#'
 #' @author Dominic Henry <dominic.henry@gmail.com> \cr
 #' Pachi Cervantes
 #' @seealso \code{\link[spOccupancy]{spPGOcc}}, \code{\link[spOccupancy]{PGOcc}}
@@ -28,11 +32,18 @@
 #'
 #'
 #' ## Return list for spatial occupancy model
-#' abapToSpOcc_single(abap_data, abap_pentads)
+#' spOcc <- abapToSpOcc_single(abap_data, abap_pentads)
+#' str(spOcc)
+#'
+#' ## Return list for spatial occupancy model (without coordinate projection)
+#' spOcc <- abapToSpOcc_single(abap_data, abap_pentads, proj_coords = FALSE)
+#' str(spOcc)
 #'
 #' ## List for non-spatial occupancy model
-#' abapToSpOcc_single(abap_data)
-abapToSpOcc_single <- function(abap_data, pentads = NULL){
+#' spOcc <- abapToSpOcc_single(abap_data)
+#' str(spOcc)
+#'
+abapToSpOcc_single <- function(abap_data, pentads = NULL, proj_coords = TRUE){
 
     pentad_id <- unique(abap_data$Pentad)
 
@@ -47,6 +58,11 @@ abapToSpOcc_single <- function(abap_data, pentads = NULL){
     if(!is.null(pentads)){
 
         sf::st_agr(pentads) = "constant"
+        aeaproj <- "+proj=aea +lat_1=20 +lat_2=-23 +lat_0=0 +lon_0=25 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs"
+
+        if(isTRUE(proj_coords)){
+            pentads <- sf::st_transform(pentads, aeaproj)
+        }
 
         pentad_xy <- pentads %>%
             dplyr::filter(pentad %in% pentad_id) %>%

--- a/man/abapToSpOcc_single.Rd
+++ b/man/abapToSpOcc_single.Rd
@@ -4,25 +4,30 @@
 \alias{abapToSpOcc_single}
 \title{ABAP to spOccupancy (single-species)}
 \usage{
-abapToSpOcc_single(abap_data, pentads = NULL)
+abapToSpOcc_single(abap_data, pentads = NULL, proj_coords = TRUE)
 }
 \arguments{
 \item{abap_data}{single-season ABAP data downloaded using \code{\link{getAbapData}}.}
 
-\item{pentads}{an sf object returned by \code{\link{getRegionPentads}}. Defaults to \code{NULL}.}
+\item{pentads}{an \code{sf} object returned by \code{\link{getRegionPentads}}. Defaults to \code{NULL}.}
+
+\item{proj_coords}{logical value indicating whether pentad coordinates are projected (\code{TRUE}) or kept in decimal degree format (\code{FALSE}). Defaults to \code{TRUE}. See details below for coordinate reference system used during transformation.}
 }
 \value{
 A list containing data necessary for model fitting in \code{spOccupancy}. List elements are \code{y} (detection/non-detection data), \code{det.covs} (survey-level covariates), and \code{coords} (x and y centroids of pentads if spatial data are supplied).
 }
 \description{
-This function transforms a raw ABAP data frame (returned by \code{\link{getAbapData}}) into an list which can be used to fit single-species occupancy models using \code{\link[spOccupancy]{spPGOcc}}(spatial) or \code{\link[spOccupancy]{PGOcc}}(non-spatial). The \code{spOccupancy} package fits single-species, multi-species, and integrated non-spatial and spatial occupancy models using Markov Chain Monte Carlo (MCMC).
+This function transforms a raw ABAP data frame (returned by \code{\link{getAbapData}}) into an list which can be used to fit single-species occupancy models using \code{\link[spOccupancy]{spPGOcc}} (spatial) or \code{\link[spOccupancy]{PGOcc}} (non-spatial). The \code{spOccupancy} package fits single-species, multi-species, and integrated non-spatial and spatial occupancy models using Markov Chain Monte Carlo (MCMC).
 }
 \details{
-The \code{\link[spOccupancy]{spPGOcc}} function takes \code{coords} as an argument with X and Y coordinates included for each site. Within the context of ABAP these \code{coords} are the centroid of each sampling pentad. In order to provide these spatial data to this function, simply use \code{\link{getRegionPentads}} and provide the same inputs for \code{.region_type} and \code{.region} that are specified in corresponding \code{\link{getAbapData}} call.\cr
+The \code{\link[spOccupancy]{spPGOcc}} function takes \code{coords} as an argument with X and Y coordinates included for each site. Within the context of ABAP, these \code{coords} are the centroid of each sampling pentad. In order to provide these spatial data to this function, simply use \code{\link{getRegionPentads}} and provide the same inputs for \code{.region_type} and \code{.region} that are specified in corresponding \code{\link{getAbapData}} call. If proj_coords is set to \code{TRUE} then the coordinates will be transformed using the African Albers Equal Area coordinate system (see \href{https://spatialreference.org/ref/esri/africa-albers-equal-area-conic/}{here} for details). This projection is best suited for land masses extending in an east-to-west orientation at mid-latitudes making it suitable for projecting pentads in Southern Africa. The functions in the \code{spOccupancy} package assume that coordinates are projected so for best results it is recommended to always project the data. \cr
 
 If \code{pentads} are specified then the output can be automatically used in \code{\link[spOccupancy]{spPGOcc}}. If no spatial data are provided the output can be used in \code{\link[spOccupancy]{PGOcc}}.\cr
 
 In addition to reformatting the detection/non-detection ABAP data for use in \code{spOccupancy} occupancy models, this function also extracts two survey-level covariates and adds them to the output list: \code{ hours} and \code{jday}. The \code{hours} variable is the total number of hours spent atlassing which is recorded on the pentad card and \code{jday} is the Julian day corresponding to the first day of atlassing for that card.
+}
+\note{
+The processing time of \code{abapToSpOcc_single} can be considerably long if the number of cards and pentads of the focal species is high, so patience may be required.
 }
 \examples{
 abap_data <- getAbapData(.spp_code = 212,
@@ -35,10 +40,17 @@ abap_pentads <- getRegionPentads(.region_type = "province",
 
 
 ## Return list for spatial occupancy model
-abapToSpOcc_single(abap_data, abap_pentads)
+spOcc <- abapToSpOcc_single(abap_data, abap_pentads)
+str(spOcc)
+
+## Return list for spatial occupancy model (without coordinate projection)
+spOcc <- abapToSpOcc_single(abap_data, abap_pentads, proj_coords = FALSE)
+str(spOcc)
 
 ## List for non-spatial occupancy model
-abapToSpOcc_single(abap_data)
+spOcc <- abapToSpOcc_single(abap_data)
+str(spOcc)
+
 }
 \seealso{
 \code{\link[spOccupancy]{spPGOcc}}, \code{\link[spOccupancy]{PGOcc}}


### PR DESCRIPTION
`spOccupancy` assumes that coords are projected when calculating distance and weighting matrices. The default behaviour is now to project using Albers Equal which is a reasonable projection when working at large spatial scales. 