### PR TITLE
Pentad centroids as siteCovs

### DIFF
--- a/man/abapToUnmarked_multi.Rd
+++ b/man/abapToUnmarked_multi.Rd
@@ -4,10 +4,12 @@
 \alias{abapToUnmarked_multi}
 \title{ABAP to unmarked (multi-season)}
 \usage{
-abapToUnmarked_multi(abap_data)
+abapToUnmarked_multi(abap_data, pentads = NULL)
 }
 \arguments{
 \item{abap_data}{multi-season ABAP data downloaded using \code{\link{getAbapData}}.}
+
+\item{pentads}{an \code{sf} object returned by \code{\link{getRegionPentads}}. Defaults to \code{NULL}.}
 }
 \value{
 an object of class \code{\link[unmarked]{unmarkedMultFrame}}
@@ -16,15 +18,32 @@ an object of class \code{\link[unmarked]{unmarkedMultFrame}}
 This function transforms a raw ABAP data frame (returned by \code{\link{getAbapData}}) into an \code{\link[unmarked]{unmarkedMultFrame}} object which can be used to fit dynamic occupancy models using \code{\link[unmarked]{colext}} (MacKenzie et. al 2003) and \code{\link[ubms]{stan_colext}} from the \code{ubms} package (which fits Unmarked Bayesian Models with Stan).
 }
 \details{
-In addition to reformatting the detection/non-detection ABAP data for use in \code{unmarked} and \code{ubms} occupancy models, this function also extracts two survey-level covariates: \code{hours} and \code{jday}. The \code{hours} variable is the total number of hours spent atlassing which is recorded on the pentad card and \code{jday} is the Julian day corresponding to the first day of atlassing for that card. The function also adds the sampling year as a \code{yearlySiteCovs} which allows year to be used in the formula for colonization, extinction and detection probability.
+In addition to reformatting the detection/non-detection ABAP data for use in \code{unmarked} and \code{ubms} occupancy models, this function also extracts two survey-level covariates: \code{hours} and \code{jday}. The \code{hours} variable is the total number of hours spent atlassing which is recorded on the pentad card and \code{jday} is the Julian day corresponding to the first day of atlassing for that card.\cr
+
+The function also adds the sampling year as a \code{yearlySiteCovs} which allows year to be used in the formula for colonization, extinction and detection probability.\cr
+
+If \code{pentads} are provided the \code{unmarked} frame will add the X and Y coordinates as site-level covariates (\code{siteCovs}).
+}
+\note{
+The processing time of \code{abapToUnmarked_multi} can be considerably long if the number of cards and pentads of the focal species is high, so patience may be required.
 }
 \examples{
+library(unmarked)
 abap_multi <- getAbapData(.spp = 212,
                           .region_type = "province",
                           .region = "Eastern Cape",
                           .years = c(2009,2010,2011,2012))
 
+abap_pentads <- getRegionPentads(.region_type = "province",
+                                  .region = "Eastern Cape")
+
+## Return unmarked frame no site covariates
 um_df <- abapToUnmarked_multi(abap_multi)
+summary(um_df)
+
+## Return unmarked frame with Pentad coordinates as site covariates
+um_df <- abapToUnmarked_multi(abap_data = abap_multi, pentads = abap_pentads)
+summary(um_df)
 }
 \references{
 MacKenzie, D. I., J. D. Nichols, J. E. Hines, M. G. Knutson, and A. B. Franklin. 2003. Estimating site occupancy, colonization, and local extinction when a species is detected imperfectly. Ecology 84:2200-2207.


### PR DESCRIPTION
Added the option to include pentad centroids as coordinates in the siteCovs slot of unmarked multi frame.