### PR TITLE
Remove geometry col if ee_data is a sf object

### DIFF
--- a/R/addEEtoUnmarked_single.R
+++ b/R/addEEtoUnmarked_single.R
@@ -128,6 +128,7 @@ addEEtoUnmarked_single <- function(umf, ee_data) {
 
     site_cov <- ee_data %>%
         as.data.frame() %>%
+        dplyr::select(-any_of("geometry")) %>%
         dplyr::filter(pentad %in% umf_pentads) %>%
         dplyr::arrange(match(pentad, umf_pentads)) %>%
         dplyr::select(-pentad)


### PR DESCRIPTION
Hey @patchcervan, while the `as.data.frame()` call does remove the spatial attributes, the geometry column is still retained (which then shows up in the site covariates). This small addition ensures that the geometry column is removed if it exists. I've also made this change in #21. 